### PR TITLE
Fixed table creation bug

### DIFF
--- a/Storage.lua
+++ b/Storage.lua
@@ -57,12 +57,16 @@ function cStorage:OpenDB()
 		return false;
 	end
 	
-	if (
-		not(self:CreateTable("Areas", {"ID INTEGER PRIMARY KEY AUTOINCREMENT", "MinX", "MaxX", "MinZ", "MaxZ", "WorldName", "CreatorUserName"})) or
-		not(self:CreateTable("AllowedUsers", {"AreaID", "UserName"}))
-	) then
-		LOGWARNING(PluginPrefix .. "Cannot create DB tables!");
-		return false;
+	local createdTable = {
+		self:CreateTable("Areas", {"ID INTEGER PRIMARY KEY AUTOINCREMENT", "MinX", "MaxX", "MinZ", "MaxZ", "WorldName", "CreatorUserName"}),
+		self:CreateTable("AllowedUsers", {"AreaID", "UserName"}),
+		self:CreateTable("Flags", {"AreaID", "Flag", "Value"}),
+	}
+
+	for _, didCreate in pairs(createdTable) do
+		if not(didCreate) then
+			LOGWARNING(PluginPrefix .. "Cannot create DB tables!")
+			return false
 	end
 	
 	return true;

--- a/Storage.lua
+++ b/Storage.lua
@@ -57,16 +57,15 @@ function cStorage:OpenDB()
 		return false;
 	end
 	
-	local createdTable = {
-		self:CreateTable("Areas", {"ID INTEGER PRIMARY KEY AUTOINCREMENT", "MinX", "MaxX", "MinZ", "MaxZ", "WorldName", "CreatorUserName"}),
-		self:CreateTable("AllowedUsers", {"AreaID", "UserName"}),
-		self:CreateTable("Flags", {"AreaID", "Flag", "Value"}),
-	}
-
-	for _, didCreate in pairs(createdTable) do
-		if not(didCreate) then
-			LOGWARNING(PluginPrefix .. "Cannot create DB tables!")
-			return false
+	if not(
+		self:CreateTable("Areas", {"ID INTEGER PRIMARY KEY AUTOINCREMENT", "MinX", "MaxX", "MinZ", "MaxZ", "WorldName", "CreatorUserName"})
+		and
+		self:CreateTable("AllowedUsers", {"AreaID", "UserName"})
+		and
+		self:CreateTable("Flags", {"AreaID", "Flag", "Value"})
+	) then
+		LOGWARNING(PluginPrefix .. "Cannot create DB tables!")
+		return false
 	end
 	
 	return true;


### PR DESCRIPTION
The current solution won't actually create missing tables.
Given:
```lua
if funcReturnsTrue() or funcReturnsFalse() then
    ...
end
```
I think Lua sees that the first function returns true and doesn't call the other functions, which means the database table won't be created.

I put the table creation return result into a table so that future versions can add more tables as needed.

This PR will also allow newer versions of the plugin to create new tables!